### PR TITLE
fix: Update color for info state (#45)

### DIFF
--- a/src/components/tabs/AntTabItem.vue
+++ b/src/components/tabs/AntTabItem.vue
@@ -56,13 +56,13 @@ const containerClasses = computed(() => {
   };
   const activeVariants: Record<TabItemState, string> = {
     [TabItemState.base]: 'text-primary-500 border-primary-500',
-    [TabItemState.info]: 'text-primary-500 border-primary-500',
+    [TabItemState.info]: 'text-info-500 border-info-500',
     [TabItemState.warning]: 'text-warning-500 border-warning-500',
     [TabItemState.danger]: 'text-danger-500 border-danger-500',
   };
   const notActiveVariants: Record<TabItemState, string> = {
     [TabItemState.base]: 'text-for-white-bg-font',
-    [TabItemState.info]: 'text-primary-500',
+    [TabItemState.info]: 'text-info-500',
     [TabItemState.warning]: 'text-warning-500',
     [TabItemState.danger]: 'text-danger-500',
   };
@@ -80,7 +80,7 @@ const containerClasses = computed(() => {
 const borderBoxClasses = computed(() => {
   const variants: Record<TabItemState, string> = {
     [TabItemState.base]: 'bg-primary-500',
-    [TabItemState.info]: 'bg-primary-500',
+    [TabItemState.info]: 'bg-info-500',
     [TabItemState.warning]: 'bg-warning-500',
     [TabItemState.danger]: 'bg-danger-500',
   };
@@ -93,7 +93,7 @@ const borderBoxClasses = computed(() => {
 const iconColor = computed(() => {
   const variants = {
     [TabItemState.base]: 'text-neutral-100-font',
-    [TabItemState.info]: 'text-primary-500',
+    [TabItemState.info]: 'text-info-500',
     [TabItemState.warning]: 'text-warning-500',
     [TabItemState.danger]: 'text-danger-500',
   };

--- a/src/components/tabs/__stories/AntTabs.stories.ts
+++ b/src/components/tabs/__stories/AntTabs.stories.ts
@@ -245,6 +245,7 @@ export const Summary: Story = {
         {
           id: '5',
           label: 'Fifth tab',
+          state: TabItemState.info,
         },
         {
           id: '6',
@@ -283,6 +284,11 @@ export const Summary: Story = {
         <AntFormGroupLabel>Larger container</AntFormGroupLabel>
         <div class="h-16 dashed">
           <AntTabs v-model="value_3" :tab-items="tabItems_3" expanded/>
+        </div>
+
+        <AntFormGroupLabel>Different States</AntFormGroupLabel>
+        <div class="dashed">
+          <AntTabs v-model="value_4" :tab-items="tabItems_4" />
         </div>
 
         <AntFormGroupLabel>Default Small Parent Container</AntFormGroupLabel>


### PR DESCRIPTION
Uses info instead of primary. Added different states in summary as well.