### PR TITLE
feat: Remove focus z-index

### DIFF
--- a/src/components/buttons/AntButton.vue
+++ b/src/components/buttons/AntButton.vue
@@ -108,7 +108,6 @@ const classes = computed(() => {
 
   return {
     'transition-all inline-flex items-center justify-center relative font-medium': true,
-    'focus:z-10': true,
     'active:shadow-[inset_0_4px_4px_rgba(0,0,0,0.25)]': !hasInputState.value,
     'p-1 text-xs gap-1': props.size === Size.xs2,
     'p-1.5 text-xs gap-1.5': props.size === Size.xs,

--- a/src/components/inputs/AntRangeSlider.vue
+++ b/src/components/inputs/AntRangeSlider.vue
@@ -38,7 +38,7 @@ const inputClasses = computed(() => {
   };
 
   return {
-    'ant-range-slider transition-colors relative border-none w-full focus:z-10 h-2 bg-base-300 rounded-md outline-none': true,
+    'ant-range-slider transition-colors relative border-none w-full h-2 bg-base-300 rounded-md outline-none': true,
     'disabled:opacity-50 disabled:cursor-not-allowed': props.disabled,
     'invisible': props.skeleton,
     [variants[props.state]]: true

--- a/src/components/inputs/AntSelect.vue
+++ b/src/components/inputs/AntSelect.vue
@@ -79,7 +79,7 @@ const inputClasses = computed(() => {
   };
 
   return {
-    'flex items-center transition-colors border-none outline relative focus:z-10': true,
+    'flex items-center transition-colors border-none outline relative': true,
     'outline-offset-[-1px] outline-1 focus:outline-offset-[-1px] focus:outline-1': true,
     [variants[props.state]]: true,
     // Skeleton

--- a/src/components/inputs/AntTextarea.vue
+++ b/src/components/inputs/AntTextarea.vue
@@ -70,7 +70,7 @@ const inputClasses = computed(() => {
   };
 
   return {
-    'block transition-colors relative border-none outline w-full focus:z-10 h-full text-black': true,
+    'block transition-colors relative border-none outline w-full h-full text-black': true,
     'outline-offset-[-1px] outline-1 focus:outline-offset-[-1px] focus:outline-1': true,
     'disabled:opacity-50 disabled:cursor-not-allowed': props.disabled,
     [variants[props.state]]: true,

--- a/src/components/inputs/Elements/AntBaseInput.vue
+++ b/src/components/inputs/Elements/AntBaseInput.vue
@@ -68,7 +68,7 @@ const inputClasses = computed(() => {
   };
 
   return {
-    'block transition-colors relative border-none outline w-full focus:z-10 text-black font-regular': true,
+    'block transition-colors relative border-none outline w-full text-black font-regular': true,
     'outline-offset-[-1px] outline-1 focus:outline-offset-[-1px] focus:outline-1': true,
     'disabled:opacity-50 disabled:cursor-not-allowed': props.disabled,
     'text-right': props.type === BaseInputType.number,


### PR DESCRIPTION
Resolves issue where elements "overflow" wrappers since the z-index was higher. Initially, z-index was used to properly highlight the selected element in grouped components (i.e. the outline would show around all edges end not be overlayed by adjacent elements).